### PR TITLE
🌐 Translate the menu resource forms

### DIFF
--- a/resources/lang/en/menu-builder.php
+++ b/resources/lang/en/menu-builder.php
@@ -7,6 +7,18 @@ return [
         'title' => 'Title',
         'url' => 'URL',
     ],
+    'resource' => [
+        'name' => [
+            'label' => 'Name',
+        ],
+        'locations' => [
+            'label' => 'Locations',
+            'description' => 'Choose where to display the menu.',
+        ],
+        'is_visible' => [
+            'label' => 'Visible',
+        ],
+    ],
     'actions' => [
         'add' => [
             'label' => 'Add to Menu',

--- a/resources/lang/vi/menu-builder.php
+++ b/resources/lang/vi/menu-builder.php
@@ -7,6 +7,18 @@ return [
         'title' => 'Tiêu đề',
         'url' => 'URL',
     ],
+    'resource' => [
+        'name' => [
+            'label' => 'Tên',
+        ],
+        'locations' => [
+            'label' => 'Vị trí',
+            'description' => 'Chọn vị trí hiển thị menu.',
+        ],
+        'is_visible' => [
+            'label' => 'Hiển thị',
+        ],
+    ],
     'actions' => [
         'add' => [
             'label' => 'Thêm vào Menu',

--- a/src/Resources/MenuResource.php
+++ b/src/Resources/MenuResource.php
@@ -29,17 +29,17 @@ class MenuResource extends Resource
             ->columns(1)
             ->schema([
                 TextInput::make('name')
-                    ->label('Tên')
+                    ->label(__('filament-menu-builder::menu-builder.resource.name.label'))
                     ->required(),
                 CheckboxList::make('locations')
                     ->bulkToggleable()
                     ->visible(fn (string $context) => $context === 'edit' && $locations)
-                    ->label('Vị trí')
+                    ->label(__('filament-menu-builder::menu-builder.resource.locations.label'))
                     ->afterStateHydrated(fn (Menu $menu, Set $set) => $set('locations', $menu->locations->pluck('location')))
-                    ->helperText('Chọn vị trí hiển thị menu.')
+                    ->helperText(__('filament-menu-builder::menu-builder.resource.locations.description'))
                     ->options($locations),
                 Toggle::make('is_visible')
-                    ->label('Hiển thị')
+                    ->label(__('filament-menu-builder::menu-builder.resource.is_visible.label'))
                     ->default(true),
             ]);
     }
@@ -50,9 +50,9 @@ class MenuResource extends Resource
             ->columns([
                 Tables\Columns\TextColumn::make('name')
                     ->searchable()
-                    ->label('Tên'),
+                    ->label(__('filament-menu-builder::menu-builder.resource.name.label')),
                 Tables\Columns\IconColumn::make('is_visible')
-                    ->label('Hiển thị')
+                    ->label(__('filament-menu-builder::menu-builder.resource.is_visible.label'))
                     ->boolean(),
             ])
             ->actions([


### PR DESCRIPTION
Hey! Thanks for the neat plugin.

This PR moves menu resource labels/helper text into translations and adds English support.