### PR TITLE
🧑‍💻 Add support for custom menu and menu item fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,69 @@ $panel
 
 ![Model Menu Panel](./art/model-menu.png)
 
+### Custom Fields
+
+In some cases, you may want to extend menu and menu items with custom fields. To do this, start by passing an array of form components to the `addMenuFields` and `addMenuItemFields` methods when registering the plugin:
+
+```php
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
+use Datlechin\FilamentMenuBuilder\FilamentMenuBuilderPlugin;
+
+$panel
+    ...
+    ->plugin(
+        FilamentMenuBuilderPlugin::make()
+            ->addMenuFields([
+                Toggle::make('is_logged_in'),
+            ])
+            ->addMenuItemFields([
+                TextInput::make('classes'),
+            ]),
+    )
+```
+
+Next, create a migration adding the additional columns to the appropriate tables:
+
+```php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table(config('filament-menu-builder.tables.menus'), function (Blueprint $table) {
+            $table->boolean('is_logged_in')->default(false);
+        });
+
+        Schema::table(config('filament-menu-builder.tables.menu_items'), function (Blueprint $table) {
+            $table->string('classes')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table(config('filament-menu-builder.tables.menus'), function (Blueprint $table) {
+            $table->dropColumn('is_logged_in');
+        });
+
+        Schema::table(config('filament-menu-builder.tables.menu_items'), function (Blueprint $table) {
+            $table->dropColumn('classes');
+        });
+    }
+}
+```
+
+Once done, simply run `php artisan migrate`.
+
 ## Changelog
 
 Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed recently.

--- a/src/FilamentMenuBuilderPlugin.php
+++ b/src/FilamentMenuBuilderPlugin.php
@@ -13,9 +13,9 @@ class FilamentMenuBuilderPlugin implements Plugin
 {
     protected array $locations = [];
 
-    protected array $menuFields = [];
+    protected array | Closure $menuFields = [];
 
-    protected array $menuItemFields = [];
+    protected array | Closure $menuItemFields = [];
 
     /**
      * @var MenuPanel[]
@@ -109,12 +109,12 @@ class FilamentMenuBuilderPlugin implements Plugin
         return $this->locations;
     }
 
-    public function getMenuFields(): array
+    public function getMenuFields(): array | Closure
     {
         return $this->menuFields;
     }
 
-    public function getMenuItemFields(): array
+    public function getMenuItemFields(): array | Closure
     {
         return $this->menuItemFields;
     }

--- a/src/FilamentMenuBuilderPlugin.php
+++ b/src/FilamentMenuBuilderPlugin.php
@@ -12,7 +12,9 @@ use Filament\Panel;
 class FilamentMenuBuilderPlugin implements Plugin
 {
     protected array $locations = [];
+
     protected array $menuFields = [];
+
     protected array $menuItemFields = [];
 
     /**

--- a/src/FilamentMenuBuilderPlugin.php
+++ b/src/FilamentMenuBuilderPlugin.php
@@ -12,6 +12,8 @@ use Filament\Panel;
 class FilamentMenuBuilderPlugin implements Plugin
 {
     protected array $locations = [];
+    protected array $menuFields = [];
+    protected array $menuItemFields = [];
 
     /**
      * @var MenuPanel[]
@@ -76,6 +78,20 @@ class FilamentMenuBuilderPlugin implements Plugin
         return $this;
     }
 
+    public function addMenuFields(array | Closure $schema): static
+    {
+        $this->menuFields = $schema;
+
+        return $this;
+    }
+
+    public function addMenuItemFields(array | Closure $schema): static
+    {
+        $this->menuItemFields = $schema;
+
+        return $this;
+    }
+
     /**
      * @return MenuPanel[]
      */
@@ -89,5 +105,15 @@ class FilamentMenuBuilderPlugin implements Plugin
     public function getLocations(): array
     {
         return $this->locations;
+    }
+
+    public function getMenuFields(): array
+    {
+        return $this->menuFields;
+    }
+
+    public function getMenuItemFields(): array
+    {
+        return $this->menuItemFields;
     }
 }

--- a/src/Livewire/MenuItems.php
+++ b/src/Livewire/MenuItems.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace Datlechin\FilamentMenuBuilder\Livewire;
 
 use Datlechin\FilamentMenuBuilder\Enums\LinkTarget;
+use Datlechin\FilamentMenuBuilder\FilamentMenuBuilderPlugin;
 use Datlechin\FilamentMenuBuilder\Models\Menu;
 use Datlechin\FilamentMenuBuilder\Models\MenuItem;
 use Filament\Actions\Action;
 use Filament\Actions\Concerns\InteractsWithActions;
 use Filament\Actions\Contracts\HasActions;
+use Filament\Forms\Components\Group;
 use Filament\Forms\Components\Placeholder;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
@@ -100,6 +102,7 @@ class MenuItems extends Component implements HasActions, HasForms
                     ->label(__('filament-menu-builder::menu-builder.open_in.label'))
                     ->options(LinkTarget::class)
                     ->default(LinkTarget::Self),
+                Group::make()->schema(FilamentMenuBuilderPlugin::get()->getMenuItemFields()),
             ])
             ->action(
                 fn (array $data, array $arguments) => MenuItem::query()

--- a/src/Livewire/MenuItems.php
+++ b/src/Livewire/MenuItems.php
@@ -11,6 +11,7 @@ use Datlechin\FilamentMenuBuilder\Models\MenuItem;
 use Filament\Actions\Action;
 use Filament\Actions\Concerns\InteractsWithActions;
 use Filament\Actions\Contracts\HasActions;
+use Filament\Forms\Components\Component as FormComponent;
 use Filament\Forms\Components\Group;
 use Filament\Forms\Components\Placeholder;
 use Filament\Forms\Components\Select;
@@ -102,7 +103,9 @@ class MenuItems extends Component implements HasActions, HasForms
                     ->label(__('filament-menu-builder::menu-builder.open_in.label'))
                     ->options(LinkTarget::class)
                     ->default(LinkTarget::Self),
-                Group::make()->schema(FilamentMenuBuilderPlugin::get()->getMenuItemFields()),
+                Group::make()
+                    ->visible(fn (FormComponent $component) => $component->evaluate(FilamentMenuBuilderPlugin::get()->getMenuItemFields()) !== [])
+                    ->schema(FilamentMenuBuilderPlugin::get()->getMenuItemFields()),
             ])
             ->action(
                 fn (array $data, array $arguments) => MenuItem::query()

--- a/src/Resources/MenuResource.php
+++ b/src/Resources/MenuResource.php
@@ -7,6 +7,7 @@ namespace Datlechin\FilamentMenuBuilder\Resources;
 use Datlechin\FilamentMenuBuilder\FilamentMenuBuilderPlugin;
 use Datlechin\FilamentMenuBuilder\Models\Menu;
 use Filament\Forms\Components\CheckboxList;
+use Filament\Forms\Components\Group;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
 use Filament\Forms\Form;
@@ -41,6 +42,7 @@ class MenuResource extends Resource
                 Toggle::make('is_visible')
                     ->label(__('filament-menu-builder::menu-builder.resource.is_visible.label'))
                     ->default(true),
+                Group::make()->schema(FilamentMenuBuilderPlugin::get()->getMenuFields()),
             ]);
     }
 

--- a/src/Resources/MenuResource.php
+++ b/src/Resources/MenuResource.php
@@ -7,6 +7,7 @@ namespace Datlechin\FilamentMenuBuilder\Resources;
 use Datlechin\FilamentMenuBuilder\FilamentMenuBuilderPlugin;
 use Datlechin\FilamentMenuBuilder\Models\Menu;
 use Filament\Forms\Components\CheckboxList;
+use Filament\Forms\Components\Component;
 use Filament\Forms\Components\Group;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
@@ -42,7 +43,9 @@ class MenuResource extends Resource
                 Toggle::make('is_visible')
                     ->label(__('filament-menu-builder::menu-builder.resource.is_visible.label'))
                     ->default(true),
-                Group::make()->schema(FilamentMenuBuilderPlugin::get()->getMenuFields()),
+                Group::make()
+                    ->visible(fn (Component $component) => $component->evaluate(FilamentMenuBuilderPlugin::get()->getMenuFields()) !== [])
+                    ->schema(FilamentMenuBuilderPlugin::get()->getMenuFields()),
             ]);
     }
 


### PR DESCRIPTION
This adds basic support for adding extra menu and menu item fields to the forms. Right now it would require you make your own migration adding the columns but another option would be to ship the plugin with a JSON column called `data` (for example) and adding `->statePath('data')` to the `Group::make()`'s.

```php
use Filament\Forms\Components\TextInput;
use Filament\Forms\Components\Toggle;
use Datlechin\FilamentMenuBuilder\FilamentMenuBuilderPlugin;

FilamentMenuBuilderPlugin::make()
    ->addMenuFields([
        Toggle::make('is_logged_in')
            ->hint('Only show this menu item when the user is logged in.'),
    ])
    ->addMenuItemFields([
        TextInput::make('classes'),
    ]);
```