### PR TITLE
🧑‍💻 Add support for overriding the menu resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ $panel
     ...
     ->plugin(
         FilamentMenuBuilderPlugin::make()
-            ->using(MenuResource::class)
+            ->usingResource(MenuResource::class)
     )
 ```
 

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ $panel
             ])
             ->addMenuItemFields([
                 TextInput::make('classes'),
-            ]),
+            ])
     )
 ```
 
@@ -218,6 +218,42 @@ return new class extends Migration
 ```
 
 Once done, simply run `php artisan migrate`.
+
+### Customizing the Resource
+
+Out of the box, a default Menu Resource is registered with Filament when registering the plugin in the admin provider. This resource can be extended and overridden allowing for more fine-grained control.
+
+Start by extending the `Datlechin\FilamentMenuBuilder\Resources\MenuResource` class in your application. Below is an example:
+
+```php
+namespace App\Filament\Plugins\Resources;
+
+use Datlechin\FilamentMenuBuilder\Resources\MenuResource as BaseMenuResource;
+
+class MenuResource extends BaseMenuResource
+{
+    protected static ?string $navigationGroup = 'Navigation';
+
+    public static function getNavigationBadge(): ?string
+    {
+        return number_format(static::getModel()::count());
+    }
+}
+```
+
+Now pass the custom resource to `usingResource` while registering the plugin with the panel:
+
+```php
+use App\Filament\Plugins\Resources\MenuResource;
+use Datlechin\FilamentMenuBuilder\FilamentMenuBuilderPlugin;
+
+$panel
+    ...
+    ->plugin(
+        FilamentMenuBuilderPlugin::make()
+            ->using(MenuResource::class)
+    )
+```
 
 ## Changelog
 

--- a/src/FilamentMenuBuilderPlugin.php
+++ b/src/FilamentMenuBuilderPlugin.php
@@ -11,6 +11,8 @@ use Filament\Panel;
 
 class FilamentMenuBuilderPlugin implements Plugin
 {
+    protected string $resource = MenuResource::class;
+
     protected array $locations = [];
 
     protected array | Closure $menuFields = [];
@@ -29,9 +31,7 @@ class FilamentMenuBuilderPlugin implements Plugin
 
     public function register(Panel $panel): void
     {
-        $panel->resources([
-            MenuResource::class,
-        ]);
+        $panel->resources([$this->getResource()]);
     }
 
     public function boot(Panel $panel): void
@@ -50,6 +50,13 @@ class FilamentMenuBuilderPlugin implements Plugin
         $plugin = filament(app(static::class)->getId());
 
         return $plugin;
+    }
+
+    public function usingResource(string $resource): static
+    {
+        $this->resource = $resource;
+
+        return $this;
     }
 
     public function addLocation(string $key, string $label): static
@@ -92,6 +99,11 @@ class FilamentMenuBuilderPlugin implements Plugin
         $this->menuItemFields = $schema;
 
         return $this;
+    }
+
+    public function getResource(): string
+    {
+        return $this->resource;
     }
 
     /**

--- a/src/Resources/MenuResource/Pages/EditMenu.php
+++ b/src/Resources/MenuResource/Pages/EditMenu.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Datlechin\FilamentMenuBuilder\Resources\MenuResource\Pages;
 
+use Datlechin\FilamentMenuBuilder\FilamentMenuBuilderPlugin;
 use Datlechin\FilamentMenuBuilder\Models\Menu;
-use Datlechin\FilamentMenuBuilder\Resources\MenuResource;
 use Filament\Actions;
 use Filament\Forms\Components\Section;
 use Filament\Forms\Form;
@@ -15,9 +15,12 @@ use Illuminate\Support\Arr;
 
 class EditMenu extends EditRecord
 {
-    protected static string $resource = MenuResource::class;
-
     protected static string $view = 'filament-menu-builder::edit-record';
+
+    public static function getResource(): string
+    {
+        return FilamentMenuBuilderPlugin::get()->getResource();
+    }
 
     public function form(Form $form): Form
     {

--- a/src/Resources/MenuResource/Pages/ListMenus.php
+++ b/src/Resources/MenuResource/Pages/ListMenus.php
@@ -4,13 +4,16 @@ declare(strict_types=1);
 
 namespace Datlechin\FilamentMenuBuilder\Resources\MenuResource\Pages;
 
-use Datlechin\FilamentMenuBuilder\Resources\MenuResource;
+use Datlechin\FilamentMenuBuilder\FilamentMenuBuilderPlugin;
 use Filament\Actions;
 use Filament\Resources\Pages\ListRecords;
 
 class ListMenus extends ListRecords
 {
-    protected static string $resource = MenuResource::class;
+    public static function getResource(): string
+    {
+        return FilamentMenuBuilderPlugin::get()->getResource();
+    }
 
     protected function getHeaderActions(): array
     {


### PR DESCRIPTION
This adds support for overriding the menu resource.

```php
namespace App\Filament\Plugins\Resources;

use Datlechin\FilamentMenuBuilder\Resources\MenuResource as BaseMenuResource;

class MenuResource extends BaseMenuResource
{
    protected static ?string $navigationGroup = 'Navigation';

    public static function getNavigationBadge(): ?string
    {
        return number_format(static::getModel()::count());
    }
}
```

```php
use App\Filament\Plugins\Resources\MenuResource;
use Datlechin\FilamentMenuBuilder\FilamentMenuBuilderPlugin;

$panel
    ...
    ->plugin(
        FilamentMenuBuilderPlugin::make()
            ->usingResource(MenuResource::class)
    )
```