### PR TITLE
💄 Add empty state for menu panels

### DIFF
--- a/resources/lang/en/menu-builder.php
+++ b/resources/lang/en/menu-builder.php
@@ -44,4 +44,10 @@ return [
             'title' => 'Link created',
         ],
     ],
+    'panel' => [
+        'empty' => [
+            'heading' => 'No items found',
+            'description' => 'There are no items in this menu.',
+        ],
+    ],
 ];

--- a/resources/lang/vi/menu-builder.php
+++ b/resources/lang/vi/menu-builder.php
@@ -44,4 +44,10 @@ return [
             'title' => 'Liên kết đã được tạo',
         ],
     ],
+    'panel' => [
+        'empty' => [
+            'heading' => 'Không tìm thấy mục nào',
+            'description' => 'Không có mục nào trong menu này.',
+        ],
+    ],
 ];

--- a/resources/views/components/empty-state.blade.php
+++ b/resources/views/components/empty-state.blade.php
@@ -1,0 +1,11 @@
+@props([
+    'heading' => __('filament-menu-builder::menu-builder.panel.empty.heading'),
+    'description' => __('filament-menu-builder::menu-builder.panel.empty.description'),
+    'icon' => 'heroicon-o-link-slash',
+])
+
+<x-filament-tables::empty-state
+    :heading="$heading"
+    :description="$description"
+    :icon="$icon"
+/>

--- a/resources/views/livewire/panel.blade.php
+++ b/resources/views/livewire/panel.blade.php
@@ -7,10 +7,12 @@
     >
         {{ $this->form }}
 
-        <x-slot:footerActions>
-            <x-filament::button type="submit">
-                {{ __('filament-menu-builder::menu-builder.actions.add.label') }}
-            </x-filament::button>
-        </x-slot:footerActions>
+        @if ($this->items)
+            <x-slot:footerActions>
+                <x-filament::button type="submit">
+                    {{ __('filament-menu-builder::menu-builder.actions.add.label') }}
+                </x-filament::button>
+            </x-slot:footerActions>
+        @endif
     </x-filament::section>
 </form>

--- a/src/FilamentMenuBuilderPlugin.php
+++ b/src/FilamentMenuBuilderPlugin.php
@@ -61,9 +61,7 @@ class FilamentMenuBuilderPlugin implements Plugin
 
     public function addMenuPanel(MenuPanel $menuPanel): static
     {
-        if ($menuPanel->getItems()) {
-            $this->menuPanels[] = $menuPanel;
-        }
+        $this->menuPanels[] = $menuPanel;
 
         return $this;
     }

--- a/src/Livewire/MenuPanel.php
+++ b/src/Livewire/MenuPanel.php
@@ -6,7 +6,7 @@ namespace Datlechin\FilamentMenuBuilder\Livewire;
 
 use Datlechin\FilamentMenuBuilder\Contracts\MenuPanel as ContractsMenuPanel;
 use Datlechin\FilamentMenuBuilder\Models\Menu;
-use Filament\Forms\Components\CheckboxList;
+use Filament\Forms\Components;
 use Filament\Forms\Concerns\InteractsWithForms;
 use Filament\Forms\Contracts\HasForms;
 use Filament\Forms\Form;
@@ -75,13 +75,19 @@ class MenuPanel extends Component implements HasForms
 
     public function form(Form $form): Form
     {
+        $items = collect($this->items)->mapWithKeys(fn ($item) => [$item['title'] => $item['title']]);
+
         return $form
             ->schema([
-                CheckboxList::make('data')
+                Components\View::make('filament-menu-builder::components.empty-state')
+                    ->visible($items->isEmpty()),
+
+                Components\CheckboxList::make('data')
                     ->hiddenLabel()
                     ->required()
                     ->bulkToggleable()
-                    ->options(collect($this->items)->mapWithKeys(fn ($item) => [$item['title'] => $item['title']])),
+                    ->visible($items->isNotEmpty())
+                    ->options($items),
             ]);
     }
 


### PR DESCRIPTION
This replaces the current behavior of hiding empty menu panels with an empty state component. This provides a bit better UX and lets us avoid the forceful `->getItems()` query in the admin provider when registering model menu panels which can be pesky, especially with CI. Under the hood, it is utilizing Filament's empty state table component.

![Screenshot](https://i.imgur.com/hoW3jgt.png)