### PR TITLE
🐛 Fix persisting foreign ids

### DIFF
--- a/database/migrations/create_menus_table.php.stub
+++ b/database/migrations/create_menus_table.php.stub
@@ -19,8 +19,8 @@ return new class extends Migration
 
         Schema::create(config('filament-menu-builder.tables.menu_items'), function (Blueprint $table) {
             $table->id();
-            $table->foreignIdFor(Menu::class);
-            $table->foreignIdFor(Menu::class, 'parent_id')->nullable();
+            $table->foreignIdFor(Menu::class)->constrained()->cascadeOnDelete();
+            $table->foreignIdFor(Menu::class, 'parent_id')->nullable()->constrained()->nullOnDelete();
             $table->nullableMorphs('linkable');
             $table->string('title');
             $table->string('url')->nullable();
@@ -31,9 +31,11 @@ return new class extends Migration
 
         Schema::create(config('filament-menu-builder.tables.menu_locations'), function (Blueprint $table) {
             $table->id();
-            $table->foreignIdFor(Menu::class);
+            $table->foreignIdFor(Menu::class)->constrained()->cascadeOnDelete();
             $table->string('location', 50);
             $table->timestamps();
+
+            $table->unique(['menu_id', 'location']);
         });
     }
 

--- a/database/migrations/create_menus_table.php.stub
+++ b/database/migrations/create_menus_table.php.stub
@@ -31,7 +31,7 @@ return new class extends Migration
 
         Schema::create(config('filament-menu-builder.tables.menu_locations'), function (Blueprint $table) {
             $table->id();
-            $table->foreignIdFor(Menu::class);
+            $table->foreignIdFor(Menu::class)->constrained()->cascadeOnDelete();
             $table->string('location', 50);
             $table->timestamps();
         });

--- a/database/migrations/create_menus_table.php.stub
+++ b/database/migrations/create_menus_table.php.stub
@@ -34,6 +34,8 @@ return new class extends Migration
             $table->foreignIdFor(Menu::class)->constrained()->cascadeOnDelete();
             $table->string('location', 50);
             $table->timestamps();
+
+            $table->unique(['menu_id', 'location']);
         });
     }
 

--- a/database/migrations/create_menus_table.php.stub
+++ b/database/migrations/create_menus_table.php.stub
@@ -31,11 +31,9 @@ return new class extends Migration
 
         Schema::create(config('filament-menu-builder.tables.menu_locations'), function (Blueprint $table) {
             $table->id();
-            $table->foreignIdFor(Menu::class)->constrained()->cascadeOnDelete();
+            $table->foreignIdFor(Menu::class);
             $table->string('location', 50);
             $table->timestamps();
-
-            $table->unique(['menu_id', 'location']);
         });
     }
 


### PR DESCRIPTION
This fixes a few issues with the current migration:

- Menu items and locations persisting when their assigned menu is deleted.
- Menu item parent ID's persisting when deleting the parent menu item is deleted.

It also adds unique indexes for `menu_id` and `location` on the menu locations table.

I think the original migration should be fixed as seen in this PR since the plugin isn't even v1.0.0 and the migration to fix foreign id's like this generally isn't very pretty for a fresh install:

```php
<?php

use Illuminate\Database\Migrations\Migration;
use Illuminate\Database\Schema\Blueprint;
use Illuminate\Support\Facades\Schema;

return new class extends Migration
{
    /**
     * Run the migrations.
     */
    public function up(): void
    {
        Schema::table(config('filament-menu-builder.tables.menu_items'), function (Blueprint $table) {
            $table->dropForeign(['menu_id']);
            $table->dropForeign(['parent_id']);

            $table
                ->foreign('menu_id')
                ->references('id')
                ->on(config('filament-menu-builder.tables.menus'))
                ->cascadeOnDelete();

            $table
                ->foreign('parent_id')
                ->references('id')
                ->on($table->getTable())
                ->nullOnDelete();
        });

        Schema::table(config('filament-menu-builder.tables.menu_locations'), function (Blueprint $table) {
            $table->dropForeign(['menu_id']);

            $table
                ->foreign('menu_id')
                ->references('id')
                ->on(config('filament-menu-builder.tables.menus'))
                ->cascadeOnDelete();

            $table->unique(['menu_id', 'location']);
        });
    }

    /**
     * Reverse the migrations.
     */
    public function down(): void
    {
        //
    }
};
```

