### PR TITLE
🩹 Delete unregistered locations when updating menus

### DIFF
--- a/src/Resources/MenuResource/Pages/EditMenu.php
+++ b/src/Resources/MenuResource/Pages/EditMenu.php
@@ -39,7 +39,11 @@ class EditMenu extends EditRecord
 
     protected function handleRecordUpdate(Model $record, array $data): Model
     {
-        $locations = Arr::pull($data, 'locations') ?: [];
+        $registeredLocations = FilamentMenuBuilderPlugin::get()->getLocations();
+
+        $locations = collect(Arr::pull($data, 'locations') ?: [])
+            ->filter(fn ($location) => array_key_exists($location, $registeredLocations))
+            ->values();
 
         /** @var Menu */
         $record = parent::handleRecordUpdate($record, $data);


### PR DESCRIPTION
This filters menu locations against registered locations when updating to ensure locations that are no longer registered get properly deleted.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Tóm tắt bởi Sourcery

Lọc các vị trí menu so với các vị trí đã đăng ký trong quá trình cập nhật để xóa các vị trí chưa đăng ký.

Sửa lỗi:
- Đảm bảo rằng các vị trí menu được lọc so với các vị trí đã đăng ký khi cập nhật, xóa bất kỳ vị trí chưa đăng ký nào.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Filter menu locations against registered locations during updates to delete unregistered locations.

Bug Fixes:
- Ensure that menu locations are filtered against registered locations when updating, deleting any unregistered locations.

</details>

<!-- Generated by sourcery-ai[bot]: end summary -->