### PR TITLE
🧑‍💻 Ensure model menu item URLs do not get saved to the database

### DIFF
--- a/resources/lang/en/menu-builder.php
+++ b/resources/lang/en/menu-builder.php
@@ -6,6 +6,8 @@ return [
     'form' => [
         'title' => 'Title',
         'url' => 'URL',
+        'linkable_type' => 'Type',
+        'linkable_id' => 'ID',
     ],
     'resource' => [
         'name' => [
@@ -40,6 +42,7 @@ return [
         ],
     ],
     'items' => [
+        'expand' => 'Expand',
         'empty' => [
             'heading' => 'There are no items in this menu.',
         ],

--- a/resources/lang/vi/menu-builder.php
+++ b/resources/lang/vi/menu-builder.php
@@ -6,6 +6,8 @@ return [
     'form' => [
         'title' => 'Tiêu đề',
         'url' => 'URL',
+        'linkable_type' => 'Loại',
+        'linkable_id' => 'ID',
     ],
     'resource' => [
         'name' => [
@@ -40,6 +42,7 @@ return [
         ],
     ],
     'items' => [
+        'expand' => 'Mở rộng',
         'empty' => [
             'heading' => 'Không có mục nào trong menu này.',
         ],

--- a/resources/views/components/menu-item.blade.php
+++ b/resources/views/components/menu-item.blade.php
@@ -21,7 +21,7 @@
                 <x-filament::icon-button
                     icon="heroicon-o-chevron-right"
                     x-on:click="open = !open"
-                    title="Mở rộng"
+                    :tooltip="trans('filament-menu-builder::menu-builder.items.expand')"
                     color="gray"
                     class="transition duration-200 ease-in-out"
                     x-bind:class="{ 'rotate-90': open }"

--- a/src/Livewire/MenuItems.php
+++ b/src/Livewire/MenuItems.php
@@ -18,6 +18,7 @@ use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Concerns\InteractsWithForms;
 use Filament\Forms\Contracts\HasForms;
+use Filament\Forms\Get;
 use Filament\Support\Enums\ActionSize;
 use Filament\Support\Enums\MaxWidth;
 use Filament\Support\Facades\FilamentIcon;
@@ -90,14 +91,16 @@ class MenuItems extends Component implements HasActions, HasForms
                     ->label(__('filament-menu-builder::menu-builder.form.title'))
                     ->required(),
                 TextInput::make('url')
-                    ->hidden(fn (?string $state): bool => empty($state))
+                    ->hidden(fn (?string $state, Get $get): bool => blank($state) || filled($get('linkable_type')))
                     ->label(__('filament-menu-builder::menu-builder.form.url'))
                     ->required(),
                 Placeholder::make('linkable_type')
-                    ->hidden(fn (?string $state): bool => empty($state))
+                    ->label(__('filament-menu-builder::menu-builder.form.linkable_type'))
+                    ->hidden(fn (?string $state): bool => blank($state))
                     ->content(fn (string $state) => $state),
                 Placeholder::make('linkable_id')
-                    ->hidden(fn (?string $state): bool => empty($state))
+                    ->label(__('filament-menu-builder::menu-builder.form.linkable_id'))
+                    ->hidden(fn (?string $state): bool => blank($state))
                     ->content(fn (string $state) => $state),
                 Select::make('target')
                     ->label(__('filament-menu-builder::menu-builder.open_in.label'))

--- a/src/Livewire/MenuPanel.php
+++ b/src/Livewire/MenuPanel.php
@@ -54,13 +54,7 @@ class MenuPanel extends Component implements HasForms
         $this->collapsed = $menuPanel->isCollapsed();
         $this->paginated = $menuPanel->isPaginated();
         $this->perPage = $menuPanel->getPerPage();
-        $this->items = array_map(function ($item) {
-            if (isset($item['url']) && is_callable($item['url'])) {
-                $item['url'] = $item['url']();
-            }
-
-            return $item;
-        }, $menuPanel->getItems());
+        $this->items = $menuPanel->getItems();
     }
 
     public function getItems(): array

--- a/src/Livewire/MenuPanel.php
+++ b/src/Livewire/MenuPanel.php
@@ -54,7 +54,13 @@ class MenuPanel extends Component implements HasForms
         $this->collapsed = $menuPanel->isCollapsed();
         $this->paginated = $menuPanel->isPaginated();
         $this->perPage = $menuPanel->getPerPage();
-        $this->items = $menuPanel->getItems();
+        $this->items = array_map(function ($item) {
+            if (isset($item['url']) && is_callable($item['url'])) {
+                $item['url'] = $item['url']();
+            }
+
+            return $item;
+        }, $menuPanel->getItems());
     }
 
     public function getItems(): array


### PR DESCRIPTION
- 🧑‍💻 Ensure model menu item URLs do not get saved to the database
- 🌐 Add missing translations
- 💄 Change expand title to a tooltip

~~URL's otherwise get handled by the Model `url` attribute getter so we don't need the `array_map` anymore either way.~~