### PR TITLE
Fix similar titles for menu items

### DIFF
--- a/database/migrations/create_menus_table.php.stub
+++ b/database/migrations/create_menus_table.php.stub
@@ -30,7 +30,7 @@ return new class extends Migration
         });
 
         Schema::table(config('filament-menu-builder.tables.menu_items'), function (Blueprint $table) {
-            $table->string('key')->unique();
+            $table->string('key');
         });
 
         Schema::create(config('filament-menu-builder.tables.menu_locations'), function (Blueprint $table) {

--- a/database/migrations/create_menus_table.php.stub
+++ b/database/migrations/create_menus_table.php.stub
@@ -20,17 +20,14 @@ return new class extends Migration
         Schema::create(config('filament-menu-builder.tables.menu_items'), function (Blueprint $table) {
             $table->id();
             $table->foreignIdFor(Menu::class)->constrained()->cascadeOnDelete();
-            $table->foreignIdFor(Menu::class, 'parent_id')->nullable()->constrained()->nullOnDelete();
+            $table->foreignIdFor(Menu::class, 'parent_id')->nullable();
             $table->nullableMorphs('linkable');
             $table->string('title');
+            $table->string('key');
             $table->string('url')->nullable();
             $table->string('target', 10)->default(LinkTarget::Self);
             $table->integer('order')->default(0);
             $table->timestamps();
-        });
-
-        Schema::table(config('filament-menu-builder.tables.menu_items'), function (Blueprint $table) {
-            $table->string('key');
         });
 
         Schema::create(config('filament-menu-builder.tables.menu_locations'), function (Blueprint $table) {

--- a/database/migrations/create_menus_table.php.stub
+++ b/database/migrations/create_menus_table.php.stub
@@ -23,11 +23,14 @@ return new class extends Migration
             $table->foreignIdFor(Menu::class, 'parent_id')->nullable()->constrained()->nullOnDelete();
             $table->nullableMorphs('linkable');
             $table->string('title');
-            $table->string('key')->unique();
             $table->string('url')->nullable();
             $table->string('target', 10)->default(LinkTarget::Self);
             $table->integer('order')->default(0);
             $table->timestamps();
+        });
+
+        Schema::table(config('filament-menu-builder.tables.menu_items'), function (Blueprint $table) {
+            $table->string('key')->unique();
         });
 
         Schema::create(config('filament-menu-builder.tables.menu_locations'), function (Blueprint $table) {

--- a/database/migrations/create_menus_table.php.stub
+++ b/database/migrations/create_menus_table.php.stub
@@ -23,6 +23,7 @@ return new class extends Migration
             $table->foreignIdFor(Menu::class, 'parent_id')->nullable()->constrained()->nullOnDelete();
             $table->nullableMorphs('linkable');
             $table->string('title');
+            $table->string('key')->unique();
             $table->string('url')->nullable();
             $table->string('target', 10)->default(LinkTarget::Self);
             $table->integer('order')->default(0);

--- a/src/Concerns/HasMenuPanel.php
+++ b/src/Concerns/HasMenuPanel.php
@@ -16,6 +16,11 @@ trait HasMenuPanel
             ->toString();
     }
 
+    public function getMenuPanelKeyColumn(): string
+    {
+        return $this->getMenuPanelTitleColumn();
+    }
+
     public function getMenuPanelModifyQueryUsing(): callable
     {
         return fn (Builder $query) => $query;

--- a/src/Contracts/MenuPanelable.php
+++ b/src/Contracts/MenuPanelable.php
@@ -10,6 +10,8 @@ interface MenuPanelable
 
     public function getMenuPanelTitleColumn(): string;
 
+    public function getMenuPanelKeyColumn(): string;
+
     public function getMenuPanelUrlUsing(): callable;
 
     public function getMenuPanelModifyQueryUsing(): callable;

--- a/src/Livewire/MenuPanel.php
+++ b/src/Livewire/MenuPanel.php
@@ -77,7 +77,7 @@ class MenuPanel extends Component implements HasForms
         $order = $this->menu->menuItems->max('order') ?? 0;
 
         $selectedItems = collect($this->items)
-            ->filter(fn ($item) => in_array($item['title'], $this->data))
+            ->filter(fn ($item) => in_array($item['key'], $this->data))
             ->map(function ($item) use (&$order) {
                 return [
                     ...$item,
@@ -102,7 +102,7 @@ class MenuPanel extends Component implements HasForms
 
     public function form(Form $form): Form
     {
-        $items = collect($this->getItems())->mapWithKeys(fn ($item) => [$item['title'] => $item['title']]);
+        $items = collect($this->getItems())->mapWithKeys(fn ($item) => [$item['key'] => $item['title']]);
 
         return $form
             ->schema([

--- a/src/MenuPanel/ModelMenuPanel.php
+++ b/src/MenuPanel/ModelMenuPanel.php
@@ -37,6 +37,7 @@ class ModelMenuPanel extends AbstractMenuPanel
             ->get()
             ->map(fn (Model $model) => [
                 'title' => $model->{$this->model->getMenuPanelTitleColumn()},
+                'key' => $model->{$this->model->getMenuPanelKeyColumn()},
                 'linkable_type' => $model::class,
                 'linkable_id' => $model->getKey(),
             ])

--- a/src/Models/MenuItem.php
+++ b/src/Models/MenuItem.php
@@ -95,16 +95,4 @@ class MenuItem extends Model
             };
         });
     }
-
-    public function key(): Attribute
-    {
-        return Attribute::make(
-            get: function ($value) {
-                return str_replace('-'.$this->menu_id, '', $value);
-            },
-            set: function ($value) {
-                return $value.'-'.$this->menu_id;
-            }
-        );
-    }
 }

--- a/src/Models/MenuItem.php
+++ b/src/Models/MenuItem.php
@@ -95,4 +95,16 @@ class MenuItem extends Model
             };
         });
     }
+
+    public function key(): Attribute
+    {
+        return Attribute::make(
+            get: function ($value) {
+                return str_replace('-'.$this->menu_id, '', $value);
+            },
+            set: function ($value) {
+                return $value.'-'.$this->menu_id;
+            }
+        );
+    }
 }


### PR DESCRIPTION
Adding key for the menu item to unique the items when same title is used.

While using your package and when adding items which having same title i noticed the following problems:

- The similar items show once for the model menu panel.
- Adding the item will add all the similar items to the menu.

I fixed it by:
1.  Adding unique "key" column and attribute for the menu items to handle the difference.
2. Add "getMenuPanelKeyColumn" function in the HasMenuPanel and HasMenuPanel Contracts.
3. Modify the MenuPanel.php to form the items with key => title 
4. Filter items when adding by the new key column in ModelMenuPanel.php.

Hope i explained the issue and the fix clearly.

At the end, Thanks for sharing the package, It was useful.
