### PR TITLE
Add option to disable the create custom link panel.

### DIFF
--- a/resources/views/edit-record.blade.php
+++ b/resources/views/edit-record.blade.php
@@ -39,7 +39,7 @@
                 <livewire:menu-builder-panel :menu="$record" :menuPanel="$menuPanel" />
             @endforeach
 
-            @if (\Datlechin\FilamentMenuBuilder\FilamentMenuBuilderPlugin::get()->getShowCustomLink())
+            @if (\Datlechin\FilamentMenuBuilder\FilamentMenuBuilderPlugin::get()->isShowCustomLink())
                 <livewire:create-custom-link :menu="$record" />
             @endif
         </div>

--- a/resources/views/edit-record.blade.php
+++ b/resources/views/edit-record.blade.php
@@ -39,7 +39,9 @@
                 <livewire:menu-builder-panel :menu="$record" :menuPanel="$menuPanel" />
             @endforeach
 
-            <livewire:create-custom-link :menu="$record" />
+            @if (\Datlechin\FilamentMenuBuilder\FilamentMenuBuilderPlugin::get()->getShowCustomLink())
+                <livewire:create-custom-link :menu="$record" />
+            @endif
         </div>
         <div class="col-span-12 sm:col-span-8">
             <x-filament::section>

--- a/src/FilamentMenuBuilderPlugin.php
+++ b/src/FilamentMenuBuilderPlugin.php
@@ -177,7 +177,7 @@ class FilamentMenuBuilderPlugin implements Plugin
             ->all();
     }
 
-    public function getShowCustomLink(): bool
+    public function isShowCustomLink(): bool
     {
         return $this->showCustomLink;
     }

--- a/src/FilamentMenuBuilderPlugin.php
+++ b/src/FilamentMenuBuilderPlugin.php
@@ -33,6 +33,8 @@ class FilamentMenuBuilderPlugin implements Plugin
      */
     protected array $menuPanels = [];
 
+    protected bool $showCustomLink = true;
+
     public function getId(): string
     {
         return 'menu-builder';
@@ -124,6 +126,13 @@ class FilamentMenuBuilderPlugin implements Plugin
         return $this;
     }
 
+    public function showCustomLink(bool $show = true): static
+    {
+        $this->showCustomLink = $show;
+
+        return $this;
+    }
+
     public function addMenuFields(array | Closure $schema): static
     {
         $this->menuFields = $schema;
@@ -166,6 +175,11 @@ class FilamentMenuBuilderPlugin implements Plugin
         return collect($this->menuPanels)
             ->sortBy(fn (MenuPanel $menuPanel) => $menuPanel->getSort())
             ->all();
+    }
+
+    public function getShowCustomLink(): bool
+    {
+        return $this->showCustomLink;
     }
 
     public function getLocations(): array


### PR DESCRIPTION
This pull request adds the ability to disable the custom link panel. This is useful when the functionality is not needed due to adding various model panels.

Example usage:
```
\Datlechin\FilamentMenuBuilder\FilamentMenuBuilderPlugin::make()
    ->showCustomLink(false)
```

I wasn't sure whether to use `show` and `false` or `hide` and `true`. It might also be nice to allow for a Callback, let me know what you think!