### PR TITLE
Add ability to add text only items. (#47)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,13 +105,7 @@ By default, the package provides a **Custom Link** menu panel that allows you to
 
 ![Custom Link Menu Panel](https://github.com/datlechin/filament-menu-builder/raw/main/art/custom-link.png)
 
-#### Custom Text Menu Panel
-
-By default, the package provides a **Custom Text** menu panel that allows you to add custom text items to the menus.
-
-It is identical to the **Custom Link** menu except for the fact that you're not required to set a URL or target. This can be useful to add headers to mega-style menus.
-
-To enable the **Custom Text** menu panel, you can use the following when configuring the plugin.
+The panel can be disabled by using the following when configuring the plugin, should you not need this functionality.
 
 ```php
 use Datlechin\FilamentMenuBuilder\FilamentMenuBuilderPlugin;
@@ -120,7 +114,26 @@ $panel
     ...
     ->plugin(
         FilamentMenuBuilderPlugin::make()
-            ->showCustomText()
+            ->showCustomLinkPanel(false)
+    )
+```
+
+#### Custom Text Menu Panel
+
+This package provides a **Custom Text** menu panel that allows you to add custom text items to the menus.
+
+It is identical to the **Custom Link** menu panel except for the fact that you only set a title without a URL or target. This can be useful to add headers to mega-style menus.
+
+The panel is disabled by default to prevent visual clutter. To enable the Custom Text menu panel, you can use the following when configuring the plugin.
+
+```php
+use Datlechin\FilamentMenuBuilder\FilamentMenuBuilderPlugin;
+
+$panel
+    ...
+    ->plugin(
+        FilamentMenuBuilderPlugin::make()
+            ->showCustomTextPanel()
     )
 ```
 

--- a/README.md
+++ b/README.md
@@ -99,11 +99,30 @@ $panel
 
 Menu panels are the panels that contain the menu items which you can add to the menus.
 
-#### Custom Menu Panel
+#### Custom Link Menu Panel
 
 By default, the package provides a **Custom Link** menu panel that allows you to add custom links to the menus.
 
 ![Custom Link Menu Panel](https://github.com/datlechin/filament-menu-builder/raw/main/art/custom-link.png)
+
+#### Custom Text Menu Panel
+
+By default, the package provides a **Custom Text** menu panel that allows you to add custom text items to the menus.
+
+It is identical to the **Custom Link** menu except for the fact that you're not required to set a URL or target. This can be useful to add headers to mega-style menus.
+
+To enable the **Custom Text** menu panel, you can use the following when configuring the plugin.
+
+```php
+use Datlechin\FilamentMenuBuilder\FilamentMenuBuilderPlugin;
+
+$panel
+    ...
+    ->plugin(
+        FilamentMenuBuilderPlugin::make()
+            ->showCustomText()
+    )
+```
 
 #### Static Menu Panel
 

--- a/resources/lang/en/menu-builder.php
+++ b/resources/lang/en/menu-builder.php
@@ -55,6 +55,7 @@ return [
         ],
     ],
     'custom_link' => 'Custom Link',
+    'custom_text' => 'Custom Text',
     'open_in' => [
         'label' => 'Open in',
         'options' => [

--- a/resources/lang/fr/menu-builder.php
+++ b/resources/lang/fr/menu-builder.php
@@ -55,6 +55,7 @@ return [
         ],
     ],
     'custom_link' => 'Lien personnalisé',
+    'custom_text' => 'Custom Text',
     'open_in' => [
         'label' => 'Ouvrir dans',
         'options' => [

--- a/resources/lang/nl/menu-builder.php
+++ b/resources/lang/nl/menu-builder.php
@@ -55,6 +55,7 @@ return [
         ],
     ],
     'custom_link' => 'Aangepaste link',
+    'custom_text' => 'Aangepaste tekst',
     'open_in' => [
         'label' => 'Openen op',
         'options' => [

--- a/resources/lang/vi/menu-builder.php
+++ b/resources/lang/vi/menu-builder.php
@@ -55,6 +55,7 @@ return [
         ],
     ],
     'custom_link' => 'Liên kết Tùy chỉnh',
+    'custom_text' => 'Custom Text',
     'open_in' => [
         'label' => 'Mở trong',
         'options' => [

--- a/resources/views/edit-record.blade.php
+++ b/resources/views/edit-record.blade.php
@@ -42,6 +42,10 @@
             @if (\Datlechin\FilamentMenuBuilder\FilamentMenuBuilderPlugin::get()->isShowCustomLink())
                 <livewire:create-custom-link :menu="$record" />
             @endif
+
+            @if (\Datlechin\FilamentMenuBuilder\FilamentMenuBuilderPlugin::get()->isShowCustomText())
+                <livewire:create-custom-text :menu="$record" />
+            @endif
         </div>
         <div class="col-span-12 sm:col-span-8">
             <x-filament::section>

--- a/resources/views/edit-record.blade.php
+++ b/resources/views/edit-record.blade.php
@@ -39,11 +39,11 @@
                 <livewire:menu-builder-panel :menu="$record" :menuPanel="$menuPanel" />
             @endforeach
 
-            @if (\Datlechin\FilamentMenuBuilder\FilamentMenuBuilderPlugin::get()->isShowCustomLink())
+            @if (\Datlechin\FilamentMenuBuilder\FilamentMenuBuilderPlugin::get()->isShowCustomLinkPanel())
                 <livewire:create-custom-link :menu="$record" />
             @endif
 
-            @if (\Datlechin\FilamentMenuBuilder\FilamentMenuBuilderPlugin::get()->isShowCustomText())
+            @if (\Datlechin\FilamentMenuBuilder\FilamentMenuBuilderPlugin::get()->isShowCustomTextPanel())
                 <livewire:create-custom-text :menu="$record" />
             @endif
         </div>

--- a/resources/views/livewire/create-custom-text.blade.php
+++ b/resources/views/livewire/create-custom-text.blade.php
@@ -1,0 +1,16 @@
+<form wire:submit="save">
+    <x-filament::section
+        :heading="__('filament-menu-builder::menu-builder.custom_text')"
+        :collapsible="true"
+        :persist-collapsed="true"
+        id="create-custom-text"
+    >
+        {{ $this->form }}
+
+        <x-slot:footerActions>
+            <x-filament::button type="submit">
+                {{ __('filament-menu-builder::menu-builder.actions.add.label') }}
+            </x-filament::button>
+        </x-slot:footerActions>
+    </x-filament::section>
+</form>

--- a/src/FilamentMenuBuilderPlugin.php
+++ b/src/FilamentMenuBuilderPlugin.php
@@ -35,7 +35,7 @@ class FilamentMenuBuilderPlugin implements Plugin
 
     protected bool $showCustomLink = true;
 
-    protected bool $showCustomText = true;
+    protected bool $showCustomText = false;
 
     public function getId(): string
     {

--- a/src/FilamentMenuBuilderPlugin.php
+++ b/src/FilamentMenuBuilderPlugin.php
@@ -35,6 +35,8 @@ class FilamentMenuBuilderPlugin implements Plugin
 
     protected bool $showCustomLink = true;
 
+    protected bool $showCustomText = true;
+
     public function getId(): string
     {
         return 'menu-builder';
@@ -133,6 +135,13 @@ class FilamentMenuBuilderPlugin implements Plugin
         return $this;
     }
 
+    public function showCustomText(bool $show = true): static
+    {
+        $this->showCustomText = $show;
+
+        return $this;
+    }
+
     public function addMenuFields(array | Closure $schema): static
     {
         $this->menuFields = $schema;
@@ -180,6 +189,11 @@ class FilamentMenuBuilderPlugin implements Plugin
     public function isShowCustomLink(): bool
     {
         return $this->showCustomLink;
+    }
+
+    public function isShowCustomText(): bool
+    {
+        return $this->showCustomText;
     }
 
     public function getLocations(): array

--- a/src/FilamentMenuBuilderPlugin.php
+++ b/src/FilamentMenuBuilderPlugin.php
@@ -33,9 +33,9 @@ class FilamentMenuBuilderPlugin implements Plugin
      */
     protected array $menuPanels = [];
 
-    protected bool $showCustomLink = true;
+    protected bool $showCustomLinkPanel = true;
 
-    protected bool $showCustomText = false;
+    protected bool $showCustomTextPanel = false;
 
     public function getId(): string
     {
@@ -128,16 +128,16 @@ class FilamentMenuBuilderPlugin implements Plugin
         return $this;
     }
 
-    public function showCustomLink(bool $show = true): static
+    public function showCustomLinkPanel(bool $show = true): static
     {
-        $this->showCustomLink = $show;
+        $this->showCustomLinkPanel = $show;
 
         return $this;
     }
 
-    public function showCustomText(bool $show = true): static
+    public function showCustomTextPanel(bool $show = true): static
     {
-        $this->showCustomText = $show;
+        $this->showCustomTextPanel = $show;
 
         return $this;
     }
@@ -186,14 +186,14 @@ class FilamentMenuBuilderPlugin implements Plugin
             ->all();
     }
 
-    public function isShowCustomLink(): bool
+    public function isShowCustomLinkPanel(): bool
     {
-        return $this->showCustomLink;
+        return $this->showCustomLinkPanel;
     }
 
-    public function isShowCustomText(): bool
+    public function isShowCustomTextPanel(): bool
     {
-        return $this->showCustomText;
+        return $this->showCustomTextPanel;
     }
 
     public function getLocations(): array

--- a/src/FilamentMenuBuilderServiceProvider.php
+++ b/src/FilamentMenuBuilderServiceProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Datlechin\FilamentMenuBuilder;
 
 use Datlechin\FilamentMenuBuilder\Livewire\CreateCustomLink;
+use Datlechin\FilamentMenuBuilder\Livewire\CreateCustomText;
 use Datlechin\FilamentMenuBuilder\Livewire\MenuItems;
 use Datlechin\FilamentMenuBuilder\Livewire\MenuPanel;
 use Filament\Support\Assets\AlpineComponent;
@@ -63,6 +64,7 @@ class FilamentMenuBuilderServiceProvider extends PackageServiceProvider
         Livewire::component('menu-builder-items', MenuItems::class);
         Livewire::component('menu-builder-panel', MenuPanel::class);
         Livewire::component('create-custom-link', CreateCustomLink::class);
+        Livewire::component('create-custom-text', CreateCustomText::class);
     }
 
     protected function getAssetPackageName(): ?string

--- a/src/Livewire/CreateCustomText.php
+++ b/src/Livewire/CreateCustomText.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Datlechin\FilamentMenuBuilder\Livewire;
+
+use Datlechin\FilamentMenuBuilder\Models\Menu;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Concerns\InteractsWithForms;
+use Filament\Forms\Contracts\HasForms;
+use Filament\Forms\Form;
+use Filament\Notifications\Notification;
+use Illuminate\Contracts\View\View;
+use Livewire\Component;
+
+class CreateCustomText extends Component implements HasForms
+{
+    use InteractsWithForms;
+
+    public Menu $menu;
+
+    public string $title = '';
+
+    public function save(): void
+    {
+        $this->validate([
+            'title' => ['required', 'string'],
+        ]);
+
+        $this->menu
+            ->menuItems()
+            ->create([
+                'title' => $this->title,
+                'order' => $this->menu->menuItems->max('order') + 1,
+            ]);
+
+        Notification::make()
+            ->title(__('filament-menu-builder::menu-builder.notifications.created.title'))
+            ->success()
+            ->send();
+
+        $this->reset('title');
+        $this->dispatch('menu:created');
+    }
+
+    public function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                TextInput::make('title')
+                    ->label(__('filament-menu-builder::menu-builder.form.title'))
+                    ->required(),
+            ]);
+    }
+
+    public function render(): View
+    {
+        return view('filament-menu-builder::livewire.create-custom-text');
+    }
+}

--- a/src/Models/MenuItem.php
+++ b/src/Models/MenuItem.php
@@ -91,6 +91,7 @@ class MenuItem extends Model
         return Attribute::get(function () {
             return match (true) {
                 $this->linkable instanceof MenuPanelable => $this->linkable->getMenuPanelName(),
+                is_null($this->linkable) && is_null($this->url) => __('filament-menu-builder::menu-builder.custom_text'),
                 default => __('filament-menu-builder::menu-builder.custom_link'),
             };
         });


### PR DESCRIPTION
Closes #47 

This adds a panel that allows users to add an item that is text only without having to enter a URL or select a target.

I shouldn't have forgotten anything, but please give it a once-over. :)