### PR TITLE
Prevent LazyLoadingViolationException  when using strict mode

### DIFF
--- a/src/Models/MenuItem.php
+++ b/src/Models/MenuItem.php
@@ -33,6 +33,7 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
 class MenuItem extends Model
 {
     protected $guarded = [];
+
     protected $with = ['linkable'];
 
     public function getTable(): string

--- a/src/Models/MenuItem.php
+++ b/src/Models/MenuItem.php
@@ -33,6 +33,7 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
 class MenuItem extends Model
 {
     protected $guarded = [];
+    protected $with = ['linkable'];
 
     public function getTable(): string
     {


### PR DESCRIPTION
Currently when using the package in conjunction with strict models, editing a menu will fail due to a `LazyLoadingViolationException` since the `linkable` is not eager loaded with the `MenuItems`. This pull request fixes that, making the package compatible with strict mode as far as I can tell.

Although usually the use of `$with` is discouraged, it seems the `MenuItem` class heavily relies on the relationship anywhere it is used. In the future, this could be improved by introducing specific `->with()` calls on the various queries, but this should go a long way and shouldn't be too egregious.

The following should now work in the app's service provider:

```php
use Illuminate\Database\Eloquent\Model;

Model::shouldBeStrict();
```