### PR TITLE
Update the Model Menu Panel example to include the trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,14 +185,17 @@ The model menu panel allows you to add menu items from a model.
 
 To create a model menu panel, your model must implement the `\Datlechin\FilamentMenuBuilder\Contracts\MenuPanelable` interface and `\Datlechin\FilamentMenuBuilder\Concerns\HasMenuPanel` trait.
 
-Then you will need to implement the following methods:
+Then you must also implement the `getMenuPanelTitleColumn` and `getMenuPanelUrlUsing` methods. A complete example of this implementation is as follows:
 
 ```php
-use Illuminate\Database\Eloquent\Model;
+use Datlechin\FilamentMenuBuilder\Concerns\HasMenuPanel;
 use Datlechin\FilamentMenuBuilder\Contracts\MenuPanelable;
+use Illuminate\Database\Eloquent\Model;
 
 class Category extends Model implements MenuPanelable
 {
+    use HasMenuPanel;
+
     public function getMenuPanelTitleColumn(): string
     {
         return 'name';


### PR DESCRIPTION
I noticed the first time I used the package that the trait was missing from the model menu panel example. This simply adds it, making the documentation more complete. Whereas previously you would run into an error if you copy-pasted the example due to the missing trait, this should be fairly complete.