### PR TITLE
Fix duplicate model titles causing multiple items being added

### DIFF
--- a/src/Contracts/MenuPanel.php
+++ b/src/Contracts/MenuPanel.php
@@ -13,4 +13,16 @@ interface MenuPanel
     public function getItems(): array;
 
     public function getSort(): int;
+
+    public function getDescription(): ?string;
+
+    public function getIcon(): ?string;
+
+    public function isCollapsible(): bool;
+
+    public function isCollapsed(): bool;
+
+    public function isPaginated(): bool;
+
+    public function getPerPage(): int;
 }

--- a/src/Livewire/MenuPanel.php
+++ b/src/Livewire/MenuPanel.php
@@ -77,7 +77,7 @@ class MenuPanel extends Component implements HasForms
         $order = $this->menu->menuItems->max('order') ?? 0;
 
         $selectedItems = collect($this->items)
-            ->filter(fn ($item) => in_array($item['title'], $this->data))
+            ->filter(fn ($item) => in_array($item['linkable_id'] ?? $item['title'], $this->data))
             ->map(function ($item) use (&$order) {
                 return [
                     ...$item,
@@ -102,7 +102,7 @@ class MenuPanel extends Component implements HasForms
 
     public function form(Form $form): Form
     {
-        $items = collect($this->getItems())->mapWithKeys(fn ($item) => [$item['title'] => $item['title']]);
+        $items = collect($this->getItems())->mapWithKeys(fn ($item) => [$item['linkable_id'] ?? $item['title'] => $item['title']]);
 
         return $form
             ->schema([


### PR DESCRIPTION
Hey there!

This pull request aims to fix an issue where when models have shared titles, multiple items are added.

We are using translatable pages where each different language has a separate model. This is to allow for more flexibility between the different languages in terms of relations etc. This results in us having multiple "Home" pages. One for each language. This results in the model menu item panel showing 4 "Home" pages, which is desired, but when selecting one of them, it will result in all 4 of them being added due to the logic only checking `title`.

This resolve it by either checking on `linkable_id` or `title`, depending on which of the 2 array keys exist. This ensures menu items which don't have a linkable relationship like static URLs or text to continue working as before.

As a minor addition, I also added the missing methods to the MenuPanel contract. They were causing intellisense errors within the MenuPanel Livewire component.

## Future considerations

In the future, it would probably be great if this sort of logic were to be extracted to a separate class. Currently the model menu items are a bit limiting. For example, you cannot currently customize the model item's name using something like a callback, since the title is solely based on a single attribute (`getMenuPanelTitleColumn`). You could do something like `SELECT CONCAT(first_name, last_name) as full_name` and then using the `full_name` column, but this still is limiting (eg. you can't do anything based on language). This would also allow something like a `has_model` attribute to be added to simplify the retrieval of the menu item's identifier (it could be then set to either `title` or `linkable_id`).