### PR TITLE
Patch fix UI

### DIFF
--- a/resources/views/components/menu-item.blade.php
+++ b/resources/views/components/menu-item.blade.php
@@ -1,4 +1,6 @@
-@props(['item'])
+@props([
+    'item',
+])
 
 @php
     /** @var \Datlechin\FilamentMenuBuilder\Models\MenuItem $item */
@@ -14,10 +16,10 @@
     <div
         class="flex justify-between px-3 py-2 bg-white shadow-sm rounded-xl ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10"
     >
-        <div class="flex items-center gap-2">
+        <div class="flex flex-1 items-center gap-2 truncate">
             {{ $this->reorderAction }}
 
-            @if($hasChildren)
+            @if ($hasChildren)
                 <x-filament::icon-button
                     icon="heroicon-o-chevron-right"
                     x-on:click="open = !open"
@@ -53,7 +55,7 @@
         x-data="menuBuilder({ parentId: {{ $item->getKey()  }} })"
         class="mt-2 space-y-2 ms-4"
     >
-        @foreach($item->children as $child)
+        @foreach ($item->children as $child)
             <x-filament-menu-builder::menu-item :item="$child" />
         @endforeach
     </ul>

--- a/src/FilamentMenuBuilderPlugin.php
+++ b/src/FilamentMenuBuilderPlugin.php
@@ -13,6 +13,7 @@ use Datlechin\FilamentMenuBuilder\Resources\MenuResource;
 use Filament\Contracts\Plugin;
 use Filament\Panel;
 use Filament\Support\Concerns\EvaluatesClosures;
+use Illuminate\Database\Eloquent\Model;
 
 class FilamentMenuBuilderPlugin implements Plugin
 {
@@ -207,16 +208,31 @@ class FilamentMenuBuilderPlugin implements Plugin
         return $this->resource;
     }
 
+    /**
+     * @template TModel of Model
+     *
+     * @return class-string<TModel>
+     */
     public function getMenuModel(): string
     {
         return $this->menuModel;
     }
 
+    /**
+     * @template TModel of Model
+     *
+     * @return class-string<TModel>
+     */
     public function getMenuItemModel(): string
     {
         return $this->menuItemModel;
     }
 
+    /**
+     * @template TModel of Model
+     *
+     * @return class-string<TModel>
+     */
     public function getMenuLocationModel(): string
     {
         return $this->menuLocationModel;


### PR DESCRIPTION
This PR fix overlapping text on menu when url is too long

Here the default behavior.

<img width="1324" alt="Capture d’écran 2025-03-08 à 06 56 44" src="https://github.com/user-attachments/assets/01c7f525-233c-43f6-ba4f-e699e1b487a4" />

After this modification, here is the result

<img width="860" alt="Capture d’écran 2025-03-08 à 07 13 50" src="https://github.com/user-attachments/assets/c86c0d6e-c675-4a71-b235-0b90bd1f993b" />
