### PR TITLE
Searchable to checkboxlist

### DIFF
--- a/src/Livewire/MenuPanel.php
+++ b/src/Livewire/MenuPanel.php
@@ -118,6 +118,7 @@ class MenuPanel extends Component implements HasForms
                     ->hiddenLabel()
                     ->required()
                     ->bulkToggleable()
+                    ->searchable()
                     ->live(condition: $this->paginated)
                     ->visible($items->isNotEmpty())
                     ->options($items),


### PR DESCRIPTION
When having a lot of items, it becomes an annoying task to select items. This PR solves that, it allows searching checkboxes.

https://filamentphp.com/docs/3.x/forms/fields/checkbox-list#searching-options