### PR TITLE
fix: get linkable_type through getMorphClass method

### DIFF
--- a/src/MenuPanel/ModelMenuPanel.php
+++ b/src/MenuPanel/ModelMenuPanel.php
@@ -37,7 +37,7 @@ class ModelMenuPanel extends AbstractMenuPanel
             ->get()
             ->map(fn (Model $model) => [
                 'title' => $model->{$this->model->getMenuPanelTitleColumn()},
-                'linkable_type' => $model::class,
+                'linkable_type' => $model->getMorphClass(),
                 'linkable_id' => $model->getKey(),
             ])
             ->all();


### PR DESCRIPTION
When you use Relation::morphMap in your project and map e.g. 'page' => Page::class and the page implements MenuPanelable, when creating a new menu item for Page Class, the database linkable_type will be App\Models\Page instead the user defined 'page'. With my proposal - we will get the class alias with getMorphClass() and if there isn't a map we will get the class name anyway.