### PR TITLE
Fix `__PHP_Incomplete_Class` on `Menu::location` cache hit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to `filament-menu-builder` will be documented in this file.
 
+## v1.0.1 - Unreleased
+
+### Fixed
+- `Menu::location()` no longer throws `__PHP_Incomplete_Class` on cache HIT when the cache driver serializes (file / database / redis). The cached payload is now the menu id (`int`) instead of a full Eloquent graph with polymorphic relations, eliminating the failure class entirely.
+- `Cache::has()` / `Cache::get()` race in `Menu::location()` replaced with atomic `Cache::rememberForever`.
+- Driver divergence on cached `null` (redis/memcached vs file/database) eliminated via integer sentinel.
+- `MenuItem::menu()` and `MenuLocation::menu()` no longer fail outside a Filament panel context (frontend layouts, queue workers, console commands) — they fall back to the base `Menu` model when the plugin is unavailable.
+
+### Changed
+- Cache invalidation on MenuItem save/delete removed; items are no longer cached so no invalidation is needed. MenuItem deletes still cascade to children.
+- Cache key prefix bumped to `filament-menu-builder.location.v2.{location}` so existing cached payloads from `1.0.0` are not read after upgrade.
+- `Menu::clearLocationCache()` retained but deprecated; the keys-index (`filament-menu-builder.location-keys`) is no longer written.
+
+### Upgrade
+Run `php artisan cache:clear` once after upgrading. Old `1.0.0` cache entries are unreachable but leave dead data on file/database drivers until cleared.
+
 ## v1.0.0 - 2026-03-07
 
 ### Major

--- a/src/Models/Menu.php
+++ b/src/Models/Menu.php
@@ -58,19 +58,45 @@ class Menu extends Model
 
     protected static function booted(): void
     {
-        static::saved(fn () => static::clearLocationCache());
-        static::deleted(fn () => static::clearLocationCache());
+        static::saved(function (self $menu): void {
+            if (! $menu->wasChanged('is_visible')) {
+                return;
+            }
+
+            $menu->forgetLocationCaches();
+        });
+
+        static::deleted(fn (self $menu) => $menu->forgetLocationCaches());
     }
 
+    /**
+     * @deprecated Cache invalidation is handled per-event by model hooks.
+     *             Kept for backward compatibility with 1.0.0 callers.
+     */
     public static function clearLocationCache(): void
     {
-        $keys = Cache::get('filament-menu-builder.location-keys', []);
-
-        foreach ($keys as $key) {
-            Cache::forget($key);
+        try {
+            $locationModel = FilamentMenuBuilderPlugin::get()->getMenuLocationModel();
+        } catch (\Throwable) {
+            $locationModel = MenuLocation::class;
         }
 
-        Cache::forget('filament-menu-builder.location-keys');
+        $locationModel::query()
+            ->distinct()
+            ->pluck('location')
+            ->each(fn (string $location) => Cache::forget(self::locationCacheKey($location)));
+    }
+
+    public function forgetLocationCaches(): void
+    {
+        $this->locations()
+            ->pluck('location')
+            ->each(fn (string $location) => Cache::forget(self::locationCacheKey($location)));
+    }
+
+    public static function locationCacheKey(string $location): string
+    {
+        return "filament-menu-builder.location.v2.{$location}";
     }
 
     public function locations(): HasMany
@@ -89,24 +115,21 @@ class Menu extends Model
 
     public static function location(string $location): ?self
     {
-        $cacheKey = "filament-menu-builder.location.{$location}";
+        $menuId = Cache::rememberForever(
+            self::locationCacheKey($location),
+            fn (): int => (int) self::query()
+                ->where('is_visible', true)
+                ->whereRelation('locations', 'location', $location)
+                ->value('id'),
+        );
 
-        if (Cache::has($cacheKey)) {
-            return Cache::get($cacheKey);
+        if ($menuId === 0) {
+            return null;
         }
 
-        $menu = self::query()
+        return self::query()
             ->where('is_visible', true)
-            ->whereRelation('locations', 'location', $location)
             ->with('menuItems')
-            ->first();
-
-        Cache::forever($cacheKey, $menu);
-
-        $keys = Cache::get('filament-menu-builder.location-keys', []);
-        $keys[] = $cacheKey;
-        Cache::forever('filament-menu-builder.location-keys', array_unique($keys));
-
-        return $menu;
+            ->find($menuId);
     }
 }

--- a/src/Models/MenuItem.php
+++ b/src/Models/MenuItem.php
@@ -75,9 +75,7 @@ class MenuItem extends Model
 
     protected static function booted(): void
     {
-        static::saved(fn () => Menu::clearLocationCache());
-        static::deleted(function (self $menuItem) {
-            Menu::clearLocationCache();
+        static::deleted(function (self $menuItem): void {
             $menuItem->children()->each(fn (self $child) => $child->delete());
         });
     }
@@ -107,7 +105,16 @@ class MenuItem extends Model
 
     public function menu(): BelongsTo
     {
-        return $this->belongsTo(FilamentMenuBuilderPlugin::get()->getMenuModel());
+        return $this->belongsTo(self::resolveMenuModel());
+    }
+
+    protected static function resolveMenuModel(): string
+    {
+        try {
+            return FilamentMenuBuilderPlugin::get()->getMenuModel();
+        } catch (\Throwable) {
+            return Menu::class;
+        }
     }
 
     public function parent(): BelongsTo

--- a/src/Models/MenuLocation.php
+++ b/src/Models/MenuLocation.php
@@ -8,6 +8,7 @@ use Datlechin\FilamentMenuBuilder\FilamentMenuBuilderPlugin;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Cache;
 
 /**
  * @property int $id
@@ -28,12 +29,34 @@ class MenuLocation extends Model
 
     protected static function booted(): void
     {
-        static::saved(fn () => Menu::clearLocationCache());
-        static::deleted(fn () => Menu::clearLocationCache());
+        static::saved(function (self $location): void {
+            Cache::forget(Menu::locationCacheKey($location->location));
+
+            if ($location->wasChanged('location')) {
+                $original = $location->getOriginal('location');
+
+                if ($original !== null && $original !== '') {
+                    Cache::forget(Menu::locationCacheKey($original));
+                }
+            }
+        });
+
+        static::deleted(
+            fn (self $location) => Cache::forget(Menu::locationCacheKey($location->location)),
+        );
     }
 
     public function menu(): BelongsTo
     {
-        return $this->belongsTo(FilamentMenuBuilderPlugin::get()->getMenuModel());
+        return $this->belongsTo(self::resolveMenuModel());
+    }
+
+    protected static function resolveMenuModel(): string
+    {
+        try {
+            return FilamentMenuBuilderPlugin::get()->getMenuModel();
+        } catch (\Throwable) {
+            return Menu::class;
+        }
     }
 }

--- a/tests/CoverageGroup4Test.php
+++ b/tests/CoverageGroup4Test.php
@@ -84,18 +84,18 @@ it('returns true for isActive when url matches current url', function () {
 
 // --- MenuLocation::saved cache invalidation ---
 
-it('clears cache when a menu location is saved', function () {
+it('only invalidates the saved location, not unrelated locations', function () {
     $menu = Menu::create(['name' => 'Test', 'is_visible' => true]);
 
-    // Prime the cache using the location() method
     MenuLocation::create(['menu_id' => $menu->id, 'location' => 'header']);
     Menu::location('header');
-    expect(Cache::has('filament-menu-builder.location.header'))->toBeTrue();
+    expect(Cache::has(Menu::locationCacheKey('header')))->toBeTrue();
 
-    // Creating another location should clear all location caches
+    // Creating an unrelated location does not invalidate the header cache;
+    // invalidation is surgical, scoped to the affected key.
     MenuLocation::create(['menu_id' => $menu->id, 'location' => 'footer']);
 
-    expect(Cache::has('filament-menu-builder.location.header'))->toBeFalse();
+    expect(Cache::has(Menu::locationCacheKey('header')))->toBeTrue();
 });
 
 it('clears cache when a menu location is updated', function () {
@@ -103,12 +103,13 @@ it('clears cache when a menu location is updated', function () {
     $location = MenuLocation::create(['menu_id' => $menu->id, 'location' => 'header']);
 
     Menu::location('header');
-    expect(Cache::has('filament-menu-builder.location.header'))->toBeTrue();
+    expect(Cache::has(Menu::locationCacheKey('header')))->toBeTrue();
 
-    // Update location — should clear cache
+    // Update location — should clear both old and new keys
     $location->update(['location' => 'footer']);
 
-    expect(Cache::has('filament-menu-builder.location.header'))->toBeFalse();
+    expect(Cache::has(Menu::locationCacheKey('header')))->toBeFalse()
+        ->and(Cache::has(Menu::locationCacheKey('footer')))->toBeFalse();
 });
 
 it('clears cache when a menu location is deleted', function () {
@@ -116,11 +117,11 @@ it('clears cache when a menu location is deleted', function () {
     $location = MenuLocation::create(['menu_id' => $menu->id, 'location' => 'header']);
 
     Menu::location('header');
-    expect(Cache::has('filament-menu-builder.location.header'))->toBeTrue();
+    expect(Cache::has(Menu::locationCacheKey('header')))->toBeTrue();
 
     $location->delete();
 
-    expect(Cache::has('filament-menu-builder.location.header'))->toBeFalse();
+    expect(Cache::has(Menu::locationCacheKey('header')))->toBeFalse();
 });
 
 // --- MenuResource::getNavigationBadge ---
@@ -150,14 +151,14 @@ it('returns formatted count when navigation badge is enabled', function () {
     $plugin->navigationCountBadge(false);
 });
 
-// --- MenuItem cache invalidation on save/delete ---
+// --- MenuItem save/delete contract ---
 
-it('clears location cache when a menu item is saved', function () {
+it('does not invalidate location cache when a menu item is saved', function () {
     $menu = Menu::create(['name' => 'Test', 'is_visible' => true]);
     MenuLocation::create(['menu_id' => $menu->id, 'location' => 'header']);
 
     Menu::location('header');
-    expect(Cache::has('filament-menu-builder.location.header'))->toBeTrue();
+    expect(Cache::has(Menu::locationCacheKey('header')))->toBeTrue();
 
     MenuItem::create([
         'menu_id' => $menu->id,
@@ -165,15 +166,14 @@ it('clears location cache when a menu item is saved', function () {
         'order' => 1,
     ]);
 
-    expect(Cache::has('filament-menu-builder.location.header'))->toBeFalse();
+    // Items are not cached, so saving them does not need to invalidate the
+    // location → menu_id resolution cache. The new item still appears on the
+    // next lookup because menuItems are eagerly re-queried.
+    expect(Cache::has(Menu::locationCacheKey('header')))->toBeTrue();
 });
 
-it('clears cache and deletes children when a menu item is deleted', function () {
+it('cascades children when a menu item is deleted', function () {
     $menu = Menu::create(['name' => 'Test', 'is_visible' => true]);
-    MenuLocation::create(['menu_id' => $menu->id, 'location' => 'test']);
-
-    Menu::location('test');
-    expect(Cache::has('filament-menu-builder.location.test'))->toBeTrue();
 
     $parent = MenuItem::create([
         'menu_id' => $menu->id,
@@ -188,14 +188,10 @@ it('clears cache and deletes children when a menu item is deleted', function () 
         'parent_id' => $parent->id,
     ]);
 
-    // Re-prime cache
-    Menu::location('test');
-
     $parent->load('children');
     $parent->delete();
 
-    expect(Cache::has('filament-menu-builder.location.test'))->toBeFalse()
-        ->and(MenuItem::find($child->id))->toBeNull();
+    expect(MenuItem::find($child->id))->toBeNull();
 });
 
 // --- Menu::location() caching ---
@@ -213,7 +209,7 @@ it('caches menu location lookups', function () {
         ->and($result->name)->toBe('Header Menu');
 
     // Cache should now contain the result
-    expect(Cache::has('filament-menu-builder.location.header'))->toBeTrue();
+    expect(Cache::has(Menu::locationCacheKey('header')))->toBeTrue();
 });
 
 it('returns null for non-existent location', function () {

--- a/tests/CriticalBugsGroup5Test.php
+++ b/tests/CriticalBugsGroup5Test.php
@@ -83,70 +83,65 @@ it('uses per-location cache keys instead of a shared collection', function () {
         ->and($footer)->not->toBeNull()
         ->and($footer->name)->toBe('Footer Menu');
 
-    // Each location should be independently cached
-    // Clearing cache for one location should not affect the other
-    Cache::forget('filament-menu-builder.location.header');
+    // Each location is independently cached — clearing one does not affect the other.
+    Cache::forget(Menu::locationCacheKey('header'));
 
-    // Footer should still be cached (if using per-location keys)
-    // OR: if still using single key, at least both resolve correctly
+    expect(Cache::has(Menu::locationCacheKey('footer')))->toBeTrue();
+
     $footerAgain = Menu::location('footer');
     expect($footerAgain)->not->toBeNull()
         ->and($footerAgain->name)->toBe('Footer Menu');
 });
 
-it('does not lose cached locations when resolving a new one', function () {
+it('does not re-run the location resolution query on cache hit', function () {
     $menu1 = Menu::create(['name' => 'Header', 'is_visible' => true]);
     MenuLocation::create(['menu_id' => $menu1->id, 'location' => 'header']);
 
     $menu2 = Menu::create(['name' => 'Footer', 'is_visible' => true]);
     MenuLocation::create(['menu_id' => $menu2->id, 'location' => 'footer']);
 
-    // Resolve header first
-    $header = Menu::location('header');
-    expect($header->name)->toBe('Header');
+    Menu::location('header');
+    Menu::location('footer');
 
-    // Now resolve footer — header should NOT be lost from cache
-    $footer = Menu::location('footer');
-    expect($footer->name)->toBe('Footer');
-
-    // Re-resolve header — should come from cache, not re-query
-    $queryCount = 0;
-    DB::listen(function () use (&$queryCount) {
-        $queryCount++;
+    // Re-resolve header — the expensive whereRelation join against
+    // menu_locations must not run again (that is what the cache is for).
+    // The cheap `find($id)` rehydration is intentional and runs on every call.
+    $resolutionQueries = 0;
+    DB::listen(function ($query) use (&$resolutionQueries) {
+        if (str_contains($query->sql, 'menu_locations')) {
+            $resolutionQueries++;
+        }
     });
 
     $headerAgain = Menu::location('header');
-    expect($headerAgain)->not->toBeNull()
-        ->and($headerAgain->name)->toBe('Header');
 
-    // With per-location cache, this should be 0 queries
-    // With the old shared-collection approach, it might still work but is fragile
-    expect($queryCount)->toBe(0, 'Header should be served from cache without re-querying');
+    expect($headerAgain)->not->toBeNull()
+        ->and($headerAgain->name)->toBe('Header')
+        ->and($resolutionQueries)->toBe(0, 'menu_locations join should be cached');
 });
 
-it('invalidates all location caches when a menu item is saved', function () {
+it('does not invalidate location resolution cache when a menu item is saved', function () {
     $menu = Menu::create(['name' => 'Test', 'is_visible' => true]);
     MenuLocation::create(['menu_id' => $menu->id, 'location' => 'header']);
 
-    // Prime cache
     Menu::location('header');
 
-    // Create a menu item — should invalidate cache
     MenuItem::create([
         'menu_id' => $menu->id,
         'title' => 'New',
         'order' => 1,
     ]);
 
-    // The cache key(s) should be cleared
-    // Verify by checking that a fresh query runs on next location() call
-    $queried = false;
-    DB::listen(function ($query) use (&$queried) {
-        if (str_contains($query->sql, 'menus') && str_contains($query->sql, 'is_visible')) {
-            $queried = true;
+    // Items are not cached, so saving them does not need to invalidate the
+    // resolution cache. Verify by confirming the menu_locations join is not
+    // re-run after the item save.
+    $resolutionQueries = 0;
+    DB::listen(function ($query) use (&$resolutionQueries) {
+        if (str_contains($query->sql, 'menu_locations')) {
+            $resolutionQueries++;
         }
     });
 
     Menu::location('header');
-    expect($queried)->toBeTrue('Should re-query after cache invalidation');
+    expect($resolutionQueries)->toBe(0, 'Item saves must not invalidate the resolution cache');
 });

--- a/tests/Models/MenuTest.php
+++ b/tests/Models/MenuTest.php
@@ -148,14 +148,27 @@ it('caches menu location lookup', function () {
     expect($found->name)->toBe('Cached Menu');
 
     // Cache should now exist with per-location key
-    expect(Cache::has('filament-menu-builder.location.header'))->toBeTrue();
+    expect(Cache::has(Menu::locationCacheKey('header')))->toBeTrue();
 
     // Second call should return from cache
     $cached = Menu::location('header');
     expect($cached->name)->toBe('Cached Menu');
 });
 
-it('busts cache when menu is saved', function () {
+it('caches the menu id, not the eloquent graph', function () {
+    $menu = Menu::create(['name' => 'Header', 'is_visible' => true]);
+
+    MenuLocation::create([
+        'menu_id' => $menu->id,
+        'location' => 'header',
+    ]);
+
+    Menu::location('header');
+
+    expect(Cache::get(Menu::locationCacheKey('header')))->toBe($menu->id);
+});
+
+it('reflects column updates immediately even when the cache is hit', function () {
     $menu = Menu::create(['name' => 'Original', 'is_visible' => true]);
 
     MenuLocation::create([
@@ -164,10 +177,13 @@ it('busts cache when menu is saved', function () {
     ]);
 
     Menu::location('header');
-    expect(Cache::has('filament-menu-builder.location.header'))->toBeTrue();
+    expect(Cache::has(Menu::locationCacheKey('header')))->toBeTrue();
 
+    // Non-resolution columns do not invalidate the cache, but the menu is
+    // re-queried on every call, so updates are still visible.
     $menu->update(['name' => 'Updated']);
-    expect(Cache::has('filament-menu-builder.location.header'))->toBeFalse();
+    expect(Cache::has(Menu::locationCacheKey('header')))->toBeTrue();
+    expect(Menu::location('header')->name)->toBe('Updated');
 });
 
 it('busts cache when menu is deleted', function () {
@@ -179,13 +195,30 @@ it('busts cache when menu is deleted', function () {
     ]);
 
     Menu::location('header');
-    expect(Cache::has('filament-menu-builder.location.header'))->toBeTrue();
+    expect(Cache::has(Menu::locationCacheKey('header')))->toBeTrue();
 
     $menu->delete();
-    expect(Cache::has('filament-menu-builder.location.header'))->toBeFalse();
+    expect(Cache::has(Menu::locationCacheKey('header')))->toBeFalse();
 });
 
-it('busts cache when menu item is saved', function () {
+it('busts cache when is_visible toggles', function () {
+    $menu = Menu::create(['name' => 'Visible', 'is_visible' => true]);
+
+    MenuLocation::create([
+        'menu_id' => $menu->id,
+        'location' => 'header',
+    ]);
+
+    expect(Menu::location('header'))->not->toBeNull();
+    expect(Cache::has(Menu::locationCacheKey('header')))->toBeTrue();
+
+    $menu->update(['is_visible' => false]);
+
+    expect(Cache::has(Menu::locationCacheKey('header')))->toBeFalse();
+    expect(Menu::location('header'))->toBeNull();
+});
+
+it('does not invalidate location cache when a menu item is saved', function () {
     $menu = Menu::create(['name' => 'Test', 'is_visible' => true]);
 
     MenuLocation::create([
@@ -194,7 +227,7 @@ it('busts cache when menu item is saved', function () {
     ]);
 
     Menu::location('header');
-    expect(Cache::has('filament-menu-builder.location.header'))->toBeTrue();
+    expect(Cache::has(Menu::locationCacheKey('header')))->toBeTrue();
 
     MenuItem::create([
         'menu_id' => $menu->id,
@@ -203,7 +236,11 @@ it('busts cache when menu item is saved', function () {
         'order' => 1,
     ]);
 
-    expect(Cache::has('filament-menu-builder.location.header'))->toBeFalse();
+    // Items are not cached, so saving them does not need to invalidate the
+    // location → menu_id resolution cache. The new item still appears on the
+    // next lookup because menuItems are eagerly re-queried.
+    expect(Cache::has(Menu::locationCacheKey('header')))->toBeTrue();
+    expect(Menu::location('header')->menuItems)->toHaveCount(1);
 });
 
 it('busts cache when menu location is changed', function () {
@@ -215,8 +252,64 @@ it('busts cache when menu location is changed', function () {
     ]);
 
     Menu::location('header');
-    expect(Cache::has('filament-menu-builder.location.header'))->toBeTrue();
+    expect(Cache::has(Menu::locationCacheKey('header')))->toBeTrue();
 
     $location->delete();
-    expect(Cache::has('filament-menu-builder.location.header'))->toBeFalse();
+    expect(Cache::has(Menu::locationCacheKey('header')))->toBeFalse();
+});
+
+it('busts both old and new keys when a location row is renamed', function () {
+    $menu = Menu::create(['name' => 'Test', 'is_visible' => true]);
+    $location = MenuLocation::create([
+        'menu_id' => $menu->id,
+        'location' => 'header',
+    ]);
+
+    Menu::location('header');
+    expect(Cache::has(Menu::locationCacheKey('header')))->toBeTrue();
+
+    $location->update(['location' => 'footer']);
+
+    expect(Cache::has(Menu::locationCacheKey('header')))->toBeFalse()
+        ->and(Cache::has(Menu::locationCacheKey('footer')))->toBeFalse();
+});
+
+it('does not crash when MenuItem::menu is accessed outside a panel', function () {
+    $menu = Menu::create(['name' => 'Test', 'is_visible' => true]);
+    $item = MenuItem::create([
+        'menu_id' => $menu->id,
+        'title' => 'Home',
+        'url' => '/',
+        'order' => 1,
+    ]);
+
+    expect($item->menu)->toBeInstanceOf(Menu::class)
+        ->and($item->menu->is($menu))->toBeTrue();
+});
+
+it('survives a cache hit on a serializing driver', function () {
+    config()->set('cache.default', 'file');
+    Cache::store('file')->flush();
+
+    $menu = Menu::create(['name' => 'Header', 'is_visible' => true]);
+    MenuLocation::create([
+        'menu_id' => $menu->id,
+        'location' => 'header',
+    ]);
+    MenuItem::create([
+        'menu_id' => $menu->id,
+        'title' => 'Home',
+        'url' => '/',
+        'order' => 1,
+    ]);
+
+    // MISS — populates cache.
+    expect(Menu::location('header'))->toBeInstanceOf(Menu::class);
+
+    // HIT — must round-trip through serialize/unserialize without producing
+    // __PHP_Incomplete_Class. The cached payload is an int, so this is safe
+    // regardless of what models live in the menuItems graph.
+    expect(Menu::location('header'))->toBeInstanceOf(Menu::class);
+
+    Cache::store('file')->flush();
 });


### PR DESCRIPTION
## Summary

`Menu::location()` previously cached a full Eloquent graph — `Menu` + nested `MenuItem`s + their recursive `children` + the polymorphic `MenuItem::linkable()` `morphTo` whose target is an arbitrary user model. On cache HIT the cached payload was unserialized; whenever any class in that graph was unresolvable at unserialize time (missing morph alias on a frontend request, plugin not bootstrapped, model rename, package upgrade), PHP returned `__PHP_Incomplete_Class` and the `?Menu` return type tripped a `TypeError`:

> `Datlechin\FilamentMenuBuilder\Models\Menu::location(): Return value must be of type ?Menu, __PHP_Incomplete_Class returned`

The fix is architectural, not a patch: cache only the **resolution** (`location → menu_id`, an `int`), and rehydrate the menu fresh on every call via an indexed `find($id)` with a fresh `menuItems` eager load. The cached payload is now a primitive — it cannot fail to deserialize, regardless of the morph map, plugin context, or user-app classes.

While there, this also fixes a few latent bugs in the same code path:

- **TOCTOU race** between `Cache::has()` and `Cache::get()` — replaced with atomic `Cache::rememberForever`.
- **Cached-null driver divergence** — `Cache::has()` returns `false` for cached `null` on redis/memcached but `true` on file/database. Sentinel `0` ("no menu mapped to this location") eliminates the difference.
- **Non-atomic `location-keys` index** — concurrent writes dropped keys, leaking stale cache forever. Replaced with surgical per-key invalidation driven from `MenuLocation::saved`/`deleted` events (handles `wasChanged('location')` for the rename case).
- **`MenuItem::menu()` and `MenuLocation::menu()` crashed outside a Filament panel** — they unconditionally called `FilamentMenuBuilderPlugin::get()->getMenuModel()`. Now wrapped in try/catch with a fallback to the base `Menu` class, matching the pattern already used in `Menu::casts()`. Frontend layouts, queue workers, and console commands can access these relations safely.

`MenuItem` save/delete cache hooks are removed entirely — items are no longer cached, so there is nothing to invalidate. The `deleted` cascade on children is preserved.

Cache key bumped to `filament-menu-builder.location.v2.{location}` so existing `1.0.0` cached payloads are not read after upgrade. `Menu::clearLocationCache()` is kept as a deprecated public shim for backward compatibility (it now derives keys from the `MenuLocation` table instead of the deleted index).

## Test plan

- [x] All existing tests updated for the new cache key prefix and the (intentionally narrower) invalidation contract.
- [x] New regression test `survives a cache hit on a serializing driver` exercises the bug end-to-end on the file driver — passes on the new code, would fail on `1.0.0` once a polymorphic linkable is involved.
- [x] New tests cover: int payload, `is_visible` toggle invalidation, location rename invalidating both old and new keys, MenuItem::menu accessibility outside a panel, fresh column updates visible on cache hit.
- [x] `vendor/bin/pest --compact` — **307 passed, 557 assertions**.
- [x] `vendor/bin/pint --dirty --format agent` — **passed**.

## Upgrade

Run `php artisan cache:clear` once after upgrading. The `v2` key prefix means orphaned `1.0.0` entries are unreachable and harmless, but on the file/database driver they leave dead data on disk until cleared.