### PR TITLE
Refactor MenuPanelable interface for simplified API

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,9 +45,9 @@
   },
   "scripts": {
     "post-autoload-dump": "@php ./vendor/bin/testbench package:discover --ansi",
-    "test": "vendor/bin/pest",
-    "test-coverage": "vendor/bin/pest --coverage",
-    "format": "vendor/bin/pint"
+    "test": "vendor/bin/pest --parallel",
+    "test-coverage": "vendor/bin/pest --coverage --parallel --compact",
+    "format": "vendor/bin/pint --parallel"
   },
   "config": {
     "sort-packages": true,

--- a/src/Concerns/HasMenuPanel.php
+++ b/src/Concerns/HasMenuPanel.php
@@ -16,8 +16,8 @@ trait HasMenuPanel
             ->toString();
     }
 
-    public function getMenuPanelModifyQueryUsing(): callable
+    public function getMenuPanelQuery(): Builder
     {
-        return fn (Builder $query) => $query;
+        return $this->newQuery();
     }
 }

--- a/src/Contracts/MenuPanelable.php
+++ b/src/Contracts/MenuPanelable.php
@@ -8,9 +8,7 @@ interface MenuPanelable
 {
     public function getMenuPanelName(): string;
 
-    public function getMenuPanelTitleColumn(): string;
+    public function getMenuPanelTitle(): string;
 
-    public function getMenuPanelUrlUsing(): callable;
-
-    public function getMenuPanelModifyQueryUsing(): callable;
+    public function getMenuPanelUrl(): string;
 }

--- a/src/MenuPanel/ModelMenuPanel.php
+++ b/src/MenuPanel/ModelMenuPanel.php
@@ -34,10 +34,14 @@ class ModelMenuPanel extends AbstractMenuPanel
 
     public function getItems(): array
     {
-        return ($this->model->getMenuPanelModifyQueryUsing())($this->model->newQuery())
+        $query = method_exists($this->model, 'getMenuPanelQuery')
+            ? $this->model->getMenuPanelQuery()
+            : $this->model->newQuery();
+
+        return $query
             ->get()
-            ->map(fn (Model $model) => [
-                'title' => $model->{$this->model->getMenuPanelTitleColumn()},
+            ->map(fn (Model & MenuPanelable $model) => [
+                'title' => $model->getMenuPanelTitle(),
                 'linkable_type' => $model->getMorphClass(),
                 'linkable_id' => $model->getKey(),
             ])

--- a/src/Models/MenuItem.php
+++ b/src/Models/MenuItem.php
@@ -138,7 +138,7 @@ class MenuItem extends Model
     {
         return Attribute::get(function (?string $value) {
             return match (true) {
-                $this->linkable instanceof MenuPanelable => $this->linkable->getMenuPanelUrlUsing()($this->linkable),
+                $this->linkable instanceof MenuPanelable => $this->linkable->getMenuPanelUrl(),
                 default => $value,
             };
         });

--- a/tests/MenuPanel/ModelMenuPanelTest.php
+++ b/tests/MenuPanel/ModelMenuPanelTest.php
@@ -102,18 +102,13 @@ class TestPost extends Model implements MenuPanelable
         return 'Blog Posts';
     }
 
-    public function getMenuPanelTitleColumn(): string
+    public function getMenuPanelTitle(): string
     {
-        return 'title';
+        return $this->title;
     }
 
-    public function getMenuPanelUrlUsing(): callable
+    public function getMenuPanelUrl(): string
     {
-        return fn (self $model) => '/blog/' . $model->slug;
-    }
-
-    public function getMenuPanelModifyQueryUsing(): callable
-    {
-        return fn ($query) => $query;
+        return '/blog/' . $this->slug;
     }
 }

--- a/tests/Models/MenuItemLinkableTest.php
+++ b/tests/Models/MenuItemLinkableTest.php
@@ -104,18 +104,13 @@ class TestPage extends Model implements MenuPanelable
         return 'Pages';
     }
 
-    public function getMenuPanelTitleColumn(): string
+    public function getMenuPanelTitle(): string
     {
-        return 'title';
+        return $this->title;
     }
 
-    public function getMenuPanelUrlUsing(): callable
+    public function getMenuPanelUrl(): string
     {
-        return fn (self $model) => '/pages/' . $model->slug;
-    }
-
-    public function getMenuPanelModifyQueryUsing(): callable
-    {
-        return fn ($query) => $query;
+        return '/pages/' . $this->slug;
     }
 }

--- a/tests/QuickWinsGroup7Test.php
+++ b/tests/QuickWinsGroup7Test.php
@@ -86,14 +86,14 @@ class Group7TestPage extends Model implements MenuPanelable
 
     protected $guarded = [];
 
-    public function getMenuPanelTitleColumn(): string
+    public function getMenuPanelTitle(): string
     {
-        return 'name';
+        return $this->name;
     }
 
-    public function getMenuPanelUrlUsing(): callable
+    public function getMenuPanelUrl(): string
     {
-        return fn (self $model) => "/{$model->slug}";
+        return "/{$this->slug}";
     }
 }
 
@@ -106,13 +106,13 @@ class Group7TestPageWithSoftDeletes extends Model implements MenuPanelable
 
     protected $guarded = [];
 
-    public function getMenuPanelTitleColumn(): string
+    public function getMenuPanelTitle(): string
     {
-        return 'name';
+        return $this->name;
     }
 
-    public function getMenuPanelUrlUsing(): callable
+    public function getMenuPanelUrl(): string
     {
-        return fn (self $model) => "/{$model->slug}";
+        return "/{$this->slug}";
     }
 }


### PR DESCRIPTION
This PR is adjusting the code to work as it is mentioned in the README 😘

- Replace `getMenuPanelTitleColumn()` with `getMenuPanelTitle(): string`
- Replace `getMenuPanelUrlUsing(): callable` with `getMenuPanelUrl(): string`
- Replace `getMenuPanelModifyQueryUsing(): callable` with `getMenuPanelQuery(): Builder` in HasMenuPanel trait
- Update `ModelMenuPanel` and `MenuItem` to use new simpler API
- Update test fixtures accordingly